### PR TITLE
force update of landed/splashed situation when moving

### DIFF
--- a/VesselMove.cs
+++ b/VesselMove.cs
@@ -328,6 +328,9 @@ namespace VesselMover
                 {                    
                     movingVessel.SetPosition(waterSrfPoint + (moveHeight * up) + offset);
                 }
+
+                //update vessel situation to splashed down:
+                movingVessel.UpdateLandedSplashed();
             }
 
             //fix surface rotation


### PR DESCRIPTION
Moving boats the status is better updated to "splashed down", even without manually forcing them under water